### PR TITLE
version-bump player, add vast ad tag example 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "buzz-next-xymatic",
       "version": "0.1.0",
       "dependencies": {
-        "@xymatic/green-video-player-react": "~2.2.0",
+        "@xymatic/green-video-player-react": "~2.2.1",
         "next": "15.0.3",
         "react": "19.0.0-rc-66855b96-20241106",
         "react-dom": "19.0.0-rc-66855b96-20241106"
@@ -1068,18 +1068,18 @@
       "dev": true
     },
     "node_modules/@xymatic/green-video-player": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@xymatic/green-video-player/-/green-video-player-2.2.0.tgz",
-      "integrity": "sha512-JP5CgPEtvMPvK4DsoGjz/BismeInH28dhQnK+19cVDMI5n3JLTdL5qRZQFjLLo+NSvC976HcI5SWxGahigshIw==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@xymatic/green-video-player/-/green-video-player-2.2.1.tgz",
+      "integrity": "sha512-RwNk6w8+kpZfgbknl/EYO7UuO1OeFjI5BHPKMBvAluzgEz0cb+HVoVjTXhp36l6ftlnO3zOrm2R8HEdmUjnmiw==",
       "license": "SEE LICENSE IN LICENSE.md"
     },
     "node_modules/@xymatic/green-video-player-react": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@xymatic/green-video-player-react/-/green-video-player-react-2.2.0.tgz",
-      "integrity": "sha512-4qOA8dY2a4VyHlDCdv0IMI9HJtj+kk8dUmZjkzj/gPCakAR8q3cBVLShOfV3W9CfmLkYywBTY8xoNA5g7fUtVg==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@xymatic/green-video-player-react/-/green-video-player-react-2.2.1.tgz",
+      "integrity": "sha512-HBPn0je7bNZU07QvRNytpOME5HKHntXM9IrkIj1tDhCd64CLBemUBW6ZThV1z3AnVHk1lPsyYP5hUnrjed9i4Q==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@xymatic/green-video-player": "~2.2.0"
+        "@xymatic/green-video-player": "~2.2.1"
       },
       "peerDependencies": {
         "react": "^18 || ^18.0.0-0 || ^19 || ^19.0.0-0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "buzz-next-xymatic",
       "version": "0.1.0",
       "dependencies": {
-        "@xymatic/green-video-player-react": "~2.2.3",
+        "@xymatic/green-video-player-react": "~2.3.4",
         "next": "15.0.3",
         "react": "19.0.0-rc-66855b96-20241106",
         "react-dom": "19.0.0-rc-66855b96-20241106"
@@ -1068,18 +1068,18 @@
       "dev": true
     },
     "node_modules/@xymatic/green-video-player": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@xymatic/green-video-player/-/green-video-player-2.2.3.tgz",
-      "integrity": "sha512-xNV9HeZCQOOZXN0oQ2pzX4diEc6noE520Iiq++5n1KUMisvlhOYn08DFBcWzo4+z7GeHDZSYP7RlRxKGXFP2QA==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@xymatic/green-video-player/-/green-video-player-2.3.4.tgz",
+      "integrity": "sha512-tWCnCf/QlN7+6XgevmG/xsRPpLz2L/p4cYZoRbp2UEfnAm0j3T+0vr0SwNlGdgq4HG5AQIyoPHwphDoUSvbjyQ==",
       "license": "SEE LICENSE IN LICENSE.md"
     },
     "node_modules/@xymatic/green-video-player-react": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@xymatic/green-video-player-react/-/green-video-player-react-2.2.3.tgz",
-      "integrity": "sha512-WWGGMJjycW95kYg7NvHOtPLDzoChruzDOWAGP+dIyBXvbjLy4sWvTpkwn844a6R41wIiGWDztghxvBn8J4BhdQ==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@xymatic/green-video-player-react/-/green-video-player-react-2.3.4.tgz",
+      "integrity": "sha512-+0hTzz+T1J29Ojc6LQroVs9hOkVM86iTgZlvbpEHRlqYBy9qozyYxhkx6NMg+uEcdXWQpALNfiGUHpAJehwu5g==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@xymatic/green-video-player": "~2.2.3"
+        "@xymatic/green-video-player": "~2.3.4"
       },
       "peerDependencies": {
         "react": "^18 || ^18.0.0-0 || ^19 || ^19.0.0-0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "buzz-next-xymatic",
       "version": "0.1.0",
       "dependencies": {
-        "@xymatic/green-video-player-react": "~2.2.1",
+        "@xymatic/green-video-player-react": "~2.2.3",
         "next": "15.0.3",
         "react": "19.0.0-rc-66855b96-20241106",
         "react-dom": "19.0.0-rc-66855b96-20241106"
@@ -1068,18 +1068,18 @@
       "dev": true
     },
     "node_modules/@xymatic/green-video-player": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@xymatic/green-video-player/-/green-video-player-2.2.1.tgz",
-      "integrity": "sha512-RwNk6w8+kpZfgbknl/EYO7UuO1OeFjI5BHPKMBvAluzgEz0cb+HVoVjTXhp36l6ftlnO3zOrm2R8HEdmUjnmiw==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@xymatic/green-video-player/-/green-video-player-2.2.3.tgz",
+      "integrity": "sha512-xNV9HeZCQOOZXN0oQ2pzX4diEc6noE520Iiq++5n1KUMisvlhOYn08DFBcWzo4+z7GeHDZSYP7RlRxKGXFP2QA==",
       "license": "SEE LICENSE IN LICENSE.md"
     },
     "node_modules/@xymatic/green-video-player-react": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@xymatic/green-video-player-react/-/green-video-player-react-2.2.1.tgz",
-      "integrity": "sha512-HBPn0je7bNZU07QvRNytpOME5HKHntXM9IrkIj1tDhCd64CLBemUBW6ZThV1z3AnVHk1lPsyYP5hUnrjed9i4Q==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@xymatic/green-video-player-react/-/green-video-player-react-2.2.3.tgz",
+      "integrity": "sha512-WWGGMJjycW95kYg7NvHOtPLDzoChruzDOWAGP+dIyBXvbjLy4sWvTpkwn844a6R41wIiGWDztghxvBn8J4BhdQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@xymatic/green-video-player": "~2.2.1"
+        "@xymatic/green-video-player": "~2.2.3"
       },
       "peerDependencies": {
         "react": "^18 || ^18.0.0-0 || ^19 || ^19.0.0-0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "react": "19.0.0-rc-66855b96-20241106",
     "react-dom": "19.0.0-rc-66855b96-20241106",
     "next": "15.0.3",
-    "@xymatic/green-video-player-react": "~2.2.1"
+    "@xymatic/green-video-player-react": "~2.2.3"
   },
   "devDependencies": {
     "typescript": "^5",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "react": "19.0.0-rc-66855b96-20241106",
     "react-dom": "19.0.0-rc-66855b96-20241106",
     "next": "15.0.3",
-    "@xymatic/green-video-player-react": "~2.2.0"
+    "@xymatic/green-video-player-react": "~2.2.1"
   },
   "devDependencies": {
     "typescript": "^5",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "react": "19.0.0-rc-66855b96-20241106",
     "react-dom": "19.0.0-rc-66855b96-20241106",
     "next": "15.0.3",
-    "@xymatic/green-video-player-react": "~2.2.3"
+    "@xymatic/green-video-player-react": "~2.3.4"
   },
   "devDependencies": {
     "typescript": "^5",

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -46,6 +46,11 @@ export const VideoPlayer: FC = () => {
           ],
         }}
         onEvent={onEvent}
+        plugins={{
+          pluginAdGetExternalVastTag: async function () {
+            return 'https://pubads.g.doubleclick.net/gampad/ads?iu=/21775744923/external/single_preroll_skippable&sz=640x480&ciu_szs=300x250%2C728x90&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&correlator='
+          },
+        }}
       />
     </div>
   );

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -39,10 +39,10 @@ export const VideoPlayer: FC = () => {
           contents: [
             sampleContents[0],
             sampleContents[1],
+            sampleContents[2],
             sampleContents[0],
             sampleContents[1],
-            sampleContents[0],
-            sampleContents[1],
+            sampleContents[2],
           ],
         }}
         onEvent={onEvent}

--- a/src/data/sampleContents.json
+++ b/src/data/sampleContents.json
@@ -3,118 +3,62 @@
     "vendorSpecificId": "OjCSA3z8qP0j",
     "adsDisallowed": false,
     "date": "2025-01-17T12:00:00.000Z",
-    "deleted": false,
     "duration": 81,
-    "enabled": true,
     "modifiedDate": "2025-01-17T12:00:00.000Z",
     "poster": [
       {
         "src": "https://images.t-online.de/2025/01/2lXucZZHLst2/0x0:1920x1080/fit-in/__WIDTH__x0/keine-begruessung-der-tiktoker-brooklyn-laesst-olaf-scholz-abblitzen.jpg",
-        "name": "16:9 Poster",
-        "type": "image/jpeg",
         "width": 1920,
-        "format": "DEFAULT",
         "height": 1080,
-        "status": "COMPLETE",
-        "version": 1,
-        "originalFilename": "keine-begruessung-der-tiktoker-brooklyn-laesst-olaf-scholz-abblitzen.jpg",
-        "generatedFileName": "keine-begruessung-der-tiktoker-brooklyn-laesst-olaf-scholz-abblitzen.jpg"
+        "version": 1
       }
     ],
     "posterRenditions": [
       {
         "src": "https://images.t-online.de/2025/01/2lXucZZHLst2/0x0:1920x1080/fit-in/__WIDTH__x0/keine-begruessung-der-tiktoker-brooklyn-laesst-olaf-scholz-abblitzen.jpg",
-        "name": "POSTER",
-        "size": 14855,
-        "type": "image/jpeg",
-        "count": 1,
         "width": 1920,
         "height": 1080,
-        "status": "COMPLETE",
-        "version": 1,
-        "duration": 0,
-        "progress": 1,
-        "srcArray": [
-          "https://images.t-online.de/2025/01/2lXucZZHLst2/0x0:1920x1080/fit-in/__WIDTH__x0/keine-begruessung-der-tiktoker-brooklyn-laesst-olaf-scholz-abblitzen.jpg"
-        ],
-        "completedAt": "2025-01-17T12:00:00.000Z"
-      }
-    ],
-    "thumbsRenditions": [
-      {
-        "src": "https://images.t-online.de/2025/01/2lXucZZHLst2/0x0:1920x1080/fit-in/__WIDTH__x0/keine-begruessung-der-tiktoker-brooklyn-laesst-olaf-scholz-abblitzen.jpg",
-        "name": "THUMBS",
-        "size": 1373,
-        "type": "image/jpeg",
         "count": 1,
-        "width": 100,
-        "height": 56,
-        "status": "COMPLETE",
         "version": 1,
-        "duration": 0,
-        "progress": 1,
         "srcArray": [
           "https://images.t-online.de/2025/01/2lXucZZHLst2/0x0:1920x1080/fit-in/__WIDTH__x0/keine-begruessung-der-tiktoker-brooklyn-laesst-olaf-scholz-abblitzen.jpg"
-        ],
-        "completedAt": "2025-01-17T12:00:00.000Z"
+        ]
       }
     ],
     "title": "Influencer lässt Olaf Scholz abblitzen",
-    "uid": "",
     "videoRenditions": [
       {
-        "src": "https://videos.t-online.de/2025/01/NXjTlJkqHUh5/cmaf/video.m3u8",
+        "src": "https://videos.t-online.de/2025/01/OjCSA3z8qP0j/cmaf/video.m3u8",
         "name": "HLS",
-        "size": 0,
         "type": "application/vnd.apple.mpegurl",
-        "jobId": "",
         "width": 0,
-        "format": "MONO_FLAT",
         "height": 0,
-        "status": "COMPLETE",
         "version": 1,
-        "duration": 81,
-        "progress": 1,
-        "completedAt": "2025-01-17T12:00:00.000Z"
+        "duration": 81
       }
-    ],
-    "type": "video"
+    ]
   },
   {
     "vendorSpecificId": "d160ea2b-41b5-44cc-83d7-38aee0b13bb0",
     "adsDisallowed": false,
     "date": "2024-07-01T17:34:40.877Z",
-    "deleted": false,
     "duration": 57,
-    "enabled": true,
     "modifiedDate": "2024-07-01T18:00:21.770Z",
     "poster": [
       {
         "src": "https://media.delight.video/be132c877a4e0d3cf874074f4d9bdf7885c611a1/de1d6c7997a06607772bb21cf8bf4b7ab5415fde/POSTER_USER/v0/5730229f-3834-40da-9376-f5ee209627b2.jpeg",
-        "name": "de1d6c7997a06607772bb21cf8bf4b7ab5415fde.jpeg",
-        "type": "image/jpeg",
         "width": 640,
-        "format": "DEFAULT",
         "height": 360,
-        "status": "COMPLETE",
-        "version": 0,
-        "originalFilename": "de1d6c7997a06607772bb21cf8bf4b7ab5415fde.jpeg",
-        "generatedFileName": "5730229f-3834-40da-9376-f5ee209627b2.jpeg"
+        "version": 0
       }
     ],
     "posterRenditions": [
       {
         "src": "https://media.delight.video/be132c877a4e0d3cf874074f4d9bdf7885c611a1/de1d6c7997a06607772bb21cf8bf4b7ab5415fde/MEDIA/v0/POSTER/media.0000005.jpg",
-        "name": "POSTER",
-        "size": 7744,
-        "type": "image/jpeg",
         "count": 11,
         "width": 640,
         "height": 360,
-        "status": "COMPLETE",
         "version": 0,
-        "duration": 60,
-        "progress": 1,
         "srcArray": [
           "https://media.delight.video/be132c877a4e0d3cf874074f4d9bdf7885c611a1/de1d6c7997a06607772bb21cf8bf4b7ab5415fde/MEDIA/v0/POSTER/media.0000000.jpg",
           "https://media.delight.video/be132c877a4e0d3cf874074f4d9bdf7885c611a1/de1d6c7997a06607772bb21cf8bf4b7ab5415fde/MEDIA/v0/POSTER/media.0000001.jpg",
@@ -127,26 +71,19 @@
           "https://media.delight.video/be132c877a4e0d3cf874074f4d9bdf7885c611a1/de1d6c7997a06607772bb21cf8bf4b7ab5415fde/MEDIA/v0/POSTER/media.0000008.jpg",
           "https://media.delight.video/be132c877a4e0d3cf874074f4d9bdf7885c611a1/de1d6c7997a06607772bb21cf8bf4b7ab5415fde/MEDIA/v0/POSTER/media.0000009.jpg",
           "https://media.delight.video/be132c877a4e0d3cf874074f4d9bdf7885c611a1/de1d6c7997a06607772bb21cf8bf4b7ab5415fde/MEDIA/v0/POSTER/media.0000010.jpg"
-        ],
-        "completedAt": "2024-07-01T18:00:21.561Z"
+        ]
       }
     ],
     "posterType": "CUSTOM_POSTER",
     "shortTitle": "Nachrichten & Politik",
-    "summary": "Nach heftigen Unwettern in der Schweiz bergen Rettungskräfte Menschen aus einem überfluteten Gebiet, wie Aufnahmen eines Augenzeugen zeigen. #schweiz #unwetter #überschwemmung #wallis \n\n",
+    "summary": "Nach heftigen Unwettern in der Schweiz bergen Rettungskräfte Menschen.",
     "thumbsRenditions": [
       {
         "src": "https://media.delight.video/be132c877a4e0d3cf874074f4d9bdf7885c611a1/de1d6c7997a06607772bb21cf8bf4b7ab5415fde/MEDIA/v0/THUMBS/media.0000005.jpg",
-        "name": "THUMBS",
-        "size": 1171,
-        "type": "image/jpeg",
         "count": 11,
         "width": 100,
         "height": 56,
-        "status": "COMPLETE",
         "version": 0,
-        "duration": 60,
-        "progress": 1,
         "srcArray": [
           "https://media.delight.video/be132c877a4e0d3cf874074f4d9bdf7885c611a1/de1d6c7997a06607772bb21cf8bf4b7ab5415fde/MEDIA/v0/THUMBS/media.0000000.jpg",
           "https://media.delight.video/be132c877a4e0d3cf874074f4d9bdf7885c611a1/de1d6c7997a06607772bb21cf8bf4b7ab5415fde/MEDIA/v0/THUMBS/media.0000001.jpg",
@@ -159,88 +96,57 @@
           "https://media.delight.video/be132c877a4e0d3cf874074f4d9bdf7885c611a1/de1d6c7997a06607772bb21cf8bf4b7ab5415fde/MEDIA/v0/THUMBS/media.0000008.jpg",
           "https://media.delight.video/be132c877a4e0d3cf874074f4d9bdf7885c611a1/de1d6c7997a06607772bb21cf8bf4b7ab5415fde/MEDIA/v0/THUMBS/media.0000009.jpg",
           "https://media.delight.video/be132c877a4e0d3cf874074f4d9bdf7885c611a1/de1d6c7997a06607772bb21cf8bf4b7ab5415fde/MEDIA/v0/THUMBS/media.0000010.jpg"
-        ],
-        "completedAt": "2024-07-01T18:00:21.561Z"
+        ]
       }
     ],
     "title": "Schweiz: Helikopter-Rettung aus Flut in Wallis",
-    "uid": "dTLtTAnaPPetVU6zSiuxOn4ik813",
     "userCategory": "Nachrichten & Politik",
     "userMetadata": {
-      "credit": "t-online",
-      "ingestId": "IU-4JlhU",
-      "ingestDate": "2024-07-01T18:00:02.805Z"
+      "credit": "t-online"
     },
-    "userTags": ["t-online"],
+    "userTags": [
+      "t-online"
+    ],
     "videoRenditions": [
       {
         "src": "https://media.delight.video/be132c877a4e0d3cf874074f4d9bdf7885c611a1/de1d6c7997a06607772bb21cf8bf4b7ab5415fde/MEDIA/v0/HD/media.mp4",
         "name": "HD",
-        "size": 6327754,
         "type": "video/mp4",
-        "jobId": "1719856811311-xrkl4z",
         "width": 1280,
-        "format": "MONO_FLAT",
         "height": 720,
-        "status": "COMPLETE",
         "version": 0,
-        "duration": 57,
-        "progress": 1,
-        "completedAt": "2024-07-01T18:00:21.561Z"
+        "duration": 57
       },
       {
         "src": "https://media.delight.video/be132c877a4e0d3cf874074f4d9bdf7885c611a1/de1d6c7997a06607772bb21cf8bf4b7ab5415fde/MEDIA/v0/SD/media.mp4",
         "name": "SD",
-        "size": 3033350,
         "type": "video/mp4",
-        "jobId": "1719856811311-xrkl4z",
         "width": 640,
-        "format": "MONO_FLAT",
         "height": 360,
-        "status": "COMPLETE",
         "version": 0,
-        "duration": 57,
-        "progress": 1,
-        "completedAt": "2024-07-01T18:00:21.561Z"
+        "duration": 57
       }
-    ],
-    "type": "video"
+    ]
   },
   {
     "vendorSpecificId": "27a6f219-c07c-421a-a1fb-1644ac42e65c",
     "adsDisallowed": false,
     "date": "2024-06-29T08:33:40.200Z",
-    "deleted": false,
     "duration": 32,
-    "enabled": true,
     "modifiedDate": "2024-06-29T09:00:13.500Z",
     "poster": [
       {
         "src": "https://media.delight.video/be132c877a4e0d3cf874074f4d9bdf7885c611a1/d386ce35c4f8560c93ced1d91750f7a73748fe14/POSTER_USER/v0/de9002b5-a7be-4e8e-ab2f-6a80de2444dd.jpeg",
-        "name": "d386ce35c4f8560c93ced1d91750f7a73748fe14.jpeg",
-        "type": "image/jpeg",
         "width": 640,
-        "format": "DEFAULT",
-        "height": 360,
-        "status": "COMPLETE",
         "version": 0,
-        "originalFilename": "d386ce35c4f8560c93ced1d91750f7a73748fe14.jpeg",
-        "generatedFileName": "de9002b5-a7be-4e8e-ab2f-6a80de2444dd.jpeg"
+        "height": 360
       }
     ],
     "posterRenditions": [
       {
         "src": "https://media.delight.video/be132c877a4e0d3cf874074f4d9bdf7885c611a1/d386ce35c4f8560c93ced1d91750f7a73748fe14/MEDIA/v0/POSTER/media.0000003.jpg",
-        "name": "POSTER",
-        "size": 38686,
-        "type": "image/jpeg",
         "count": 6,
-        "width": 360,
-        "height": 640,
-        "status": "COMPLETE",
         "version": 0,
-        "duration": 35,
-        "progress": 1,
         "srcArray": [
           "https://media.delight.video/be132c877a4e0d3cf874074f4d9bdf7885c611a1/d386ce35c4f8560c93ced1d91750f7a73748fe14/MEDIA/v0/POSTER/media.0000000.jpg",
           "https://media.delight.video/be132c877a4e0d3cf874074f4d9bdf7885c611a1/d386ce35c4f8560c93ced1d91750f7a73748fe14/MEDIA/v0/POSTER/media.0000001.jpg",
@@ -249,7 +155,8 @@
           "https://media.delight.video/be132c877a4e0d3cf874074f4d9bdf7885c611a1/d386ce35c4f8560c93ced1d91750f7a73748fe14/MEDIA/v0/POSTER/media.0000004.jpg",
           "https://media.delight.video/be132c877a4e0d3cf874074f4d9bdf7885c611a1/d386ce35c4f8560c93ced1d91750f7a73748fe14/MEDIA/v0/POSTER/media.0000005.jpg"
         ],
-        "completedAt": "2024-06-29T09:00:13.309Z"
+        "width": 360,
+        "height": 640
       }
     ],
     "posterType": "CUSTOM_POSTER",
@@ -258,16 +165,8 @@
     "thumbsRenditions": [
       {
         "src": "https://media.delight.video/be132c877a4e0d3cf874074f4d9bdf7885c611a1/d386ce35c4f8560c93ced1d91750f7a73748fe14/MEDIA/v0/THUMBS/media.0000003.jpg",
-        "name": "THUMBS",
-        "size": 2911,
-        "type": "image/jpeg",
         "count": 6,
-        "width": 56,
-        "height": 100,
-        "status": "COMPLETE",
         "version": 0,
-        "duration": 35,
-        "progress": 1,
         "srcArray": [
           "https://media.delight.video/be132c877a4e0d3cf874074f4d9bdf7885c611a1/d386ce35c4f8560c93ced1d91750f7a73748fe14/MEDIA/v0/THUMBS/media.0000000.jpg",
           "https://media.delight.video/be132c877a4e0d3cf874074f4d9bdf7885c611a1/d386ce35c4f8560c93ced1d91750f7a73748fe14/MEDIA/v0/THUMBS/media.0000001.jpg",
@@ -276,50 +175,37 @@
           "https://media.delight.video/be132c877a4e0d3cf874074f4d9bdf7885c611a1/d386ce35c4f8560c93ced1d91750f7a73748fe14/MEDIA/v0/THUMBS/media.0000004.jpg",
           "https://media.delight.video/be132c877a4e0d3cf874074f4d9bdf7885c611a1/d386ce35c4f8560c93ced1d91750f7a73748fe14/MEDIA/v0/THUMBS/media.0000005.jpg"
         ],
-        "completedAt": "2024-06-29T09:00:13.309Z"
+        "width": 56,
+        "height": 100
       }
     ],
     "title": "CDU-Politiker Philipp Amthor: \"Es braucht eine migrationspolitische Wende\"",
-    "uid": "dTLtTAnaPPetVU6zSiuxOn4ik813",
     "userCategory": "Nachrichten & Politik",
     "userMetadata": {
-      "credit": "t-online",
-      "ingestId": "IU-4JlhU",
-      "ingestDate": "2024-06-29T09:00:01.346Z"
+      "credit": "t-online"
     },
-    "userTags": ["t-online"],
+    "userTags": [
+      "t-online"
+    ],
     "videoRenditions": [
       {
         "src": "https://media.delight.video/be132c877a4e0d3cf874074f4d9bdf7885c611a1/d386ce35c4f8560c93ced1d91750f7a73748fe14/MEDIA/v0/HD/media.mp4",
-        "name": "HD",
-        "size": 3105284,
         "type": "video/mp4",
-        "jobId": "1719651607086-eebdzm",
-        "width": 608,
-        "format": "MONO_FLAT",
-        "height": 1080,
-        "status": "COMPLETE",
         "version": 0,
         "duration": 32,
-        "progress": 1,
-        "completedAt": "2024-06-29T09:00:13.309Z"
+        "name": "HD",
+        "width": 608,
+        "height": 1080
       },
       {
         "src": "https://media.delight.video/be132c877a4e0d3cf874074f4d9bdf7885c611a1/d386ce35c4f8560c93ced1d91750f7a73748fe14/MEDIA/v0/SD/media.mp4",
-        "name": "SD",
-        "size": 2104919,
         "type": "video/mp4",
-        "jobId": "1719651607086-eebdzm",
-        "width": 406,
-        "format": "MONO_FLAT",
-        "height": 720,
-        "status": "COMPLETE",
         "version": 0,
         "duration": 32,
-        "progress": 1,
-        "completedAt": "2024-06-29T09:00:13.309Z"
+        "name": "SD",
+        "width": 406,
+        "height": 720
       }
-    ],
-    "type": "video"
+    ]
   }
 ]

--- a/src/data/sampleContents.json
+++ b/src/data/sampleContents.json
@@ -1,5 +1,86 @@
 [
   {
+    "vendorSpecificId": "OjCSA3z8qP0j",
+    "adsDisallowed": false,
+    "date": "2025-01-17T12:00:00.000Z",
+    "deleted": false,
+    "duration": 81,
+    "enabled": true,
+    "modifiedDate": "2025-01-17T12:00:00.000Z",
+    "poster": [
+      {
+        "src": "https://images.t-online.de/2025/01/2lXucZZHLst2/0x0:1920x1080/fit-in/__WIDTH__x0/keine-begruessung-der-tiktoker-brooklyn-laesst-olaf-scholz-abblitzen.jpg",
+        "name": "16:9 Poster",
+        "type": "image/jpeg",
+        "width": 1920,
+        "format": "DEFAULT",
+        "height": 1080,
+        "status": "COMPLETE",
+        "version": 1,
+        "originalFilename": "keine-begruessung-der-tiktoker-brooklyn-laesst-olaf-scholz-abblitzen.jpg",
+        "generatedFileName": "keine-begruessung-der-tiktoker-brooklyn-laesst-olaf-scholz-abblitzen.jpg"
+      }
+    ],
+    "posterRenditions": [
+      {
+        "src": "https://images.t-online.de/2025/01/2lXucZZHLst2/0x0:1920x1080/fit-in/__WIDTH__x0/keine-begruessung-der-tiktoker-brooklyn-laesst-olaf-scholz-abblitzen.jpg",
+        "name": "POSTER",
+        "size": 14855,
+        "type": "image/jpeg",
+        "count": 1,
+        "width": 1920,
+        "height": 1080,
+        "status": "COMPLETE",
+        "version": 1,
+        "duration": 0,
+        "progress": 1,
+        "srcArray": [
+          "https://images.t-online.de/2025/01/2lXucZZHLst2/0x0:1920x1080/fit-in/__WIDTH__x0/keine-begruessung-der-tiktoker-brooklyn-laesst-olaf-scholz-abblitzen.jpg"
+        ],
+        "completedAt": "2025-01-17T12:00:00.000Z"
+      }
+    ],
+    "thumbsRenditions": [
+      {
+        "src": "https://images.t-online.de/2025/01/2lXucZZHLst2/0x0:1920x1080/fit-in/__WIDTH__x0/keine-begruessung-der-tiktoker-brooklyn-laesst-olaf-scholz-abblitzen.jpg",
+        "name": "THUMBS",
+        "size": 1373,
+        "type": "image/jpeg",
+        "count": 1,
+        "width": 100,
+        "height": 56,
+        "status": "COMPLETE",
+        "version": 1,
+        "duration": 0,
+        "progress": 1,
+        "srcArray": [
+          "https://images.t-online.de/2025/01/2lXucZZHLst2/0x0:1920x1080/fit-in/__WIDTH__x0/keine-begruessung-der-tiktoker-brooklyn-laesst-olaf-scholz-abblitzen.jpg"
+        ],
+        "completedAt": "2025-01-17T12:00:00.000Z"
+      }
+    ],
+    "title": "Influencer lässt Olaf Scholz abblitzen",
+    "uid": "",
+    "videoRenditions": [
+      {
+        "src": "https://videos.t-online.de/2025/01/NXjTlJkqHUh5/cmaf/video.m3u8",
+        "name": "HLS",
+        "size": 0,
+        "type": "application/vnd.apple.mpegurl",
+        "jobId": "",
+        "width": 0,
+        "format": "MONO_FLAT",
+        "height": 0,
+        "status": "COMPLETE",
+        "version": 1,
+        "duration": 81,
+        "progress": 1,
+        "completedAt": "2025-01-17T12:00:00.000Z"
+      }
+    ],
+    "type": "video"
+  },
+  {
     "vendorSpecificId": "d160ea2b-41b5-44cc-83d7-38aee0b13bb0",
     "adsDisallowed": false,
     "date": "2024-07-01T17:34:40.877Z",

--- a/src/data/sampleContents.json
+++ b/src/data/sampleContents.json
@@ -2,9 +2,9 @@
   {
     "vendorSpecificId": "OjCSA3z8qP0j",
     "adsDisallowed": false,
-    "date": "2025-01-17T12:00:00.000Z",
+    "date": "2025-01-14T12:00:00.000Z",
     "duration": 81,
-    "modifiedDate": "2025-01-17T12:00:00.000Z",
+    "modifiedDate": "2025-01-14T12:00:00.000Z",
     "poster": [
       {
         "src": "https://images.t-online.de/2025/01/2lXucZZHLst2/0x0:1920x1080/fit-in/__WIDTH__x0/keine-begruessung-der-tiktoker-brooklyn-laesst-olaf-scholz-abblitzen.jpg",
@@ -26,13 +26,30 @@
       }
     ],
     "title": "Influencer lässt Olaf Scholz abblitzen",
+    "shortTitle": "Influencer lässt Olaf Scholz abblitzen",
+    "userCategory": "Nachrichten & Politik",
+    "userMetadata": {
+      "credit": "t-online"
+    },
+    "userTags": [
+      "t-online"
+    ],
     "videoRenditions": [
       {
         "src": "https://videos.t-online.de/2025/01/OjCSA3z8qP0j/cmaf/video.m3u8",
         "name": "HLS",
-        "type": "application/vnd.apple.mpegurl",
-        "width": 0,
-        "height": 0,
+        "type": "application/x-mpegurl",
+        "width": 1920,
+        "height": 1080,
+        "version": 1,
+        "duration": 81
+      },
+      {
+        "src": "https://videos.t-online.de/2025/01/OjCSA3z8qP0j/mp4/video.mp4",
+        "name": "HD",
+        "type": "video/mp4",
+        "width": 1920,
+        "height": 1080,
         "version": 1,
         "duration": 81
       }


### PR DESCRIPTION
* version-bumped player
   * reduced unminified bundle size
   * improved hls support
* added one more content
* added example for ad VAST tag